### PR TITLE
Add entry pass generator project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/entry_pass_generator/Dockerfile
+++ b/entry_pass_generator/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY . .
+RUN pip install --no-cache-dir poetry && poetry install --only main
+CMD ["uvicorn", "entry_pass_generator.webhook:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/entry_pass_generator/README.md
+++ b/entry_pass_generator/README.md
@@ -1,0 +1,35 @@
+# Entry Pass Generator
+
+Приложение автоматизирует создание служебной записки на въезд и отправку её в службу безопасности.
+
+## Установка
+
+```bash
+poetry install
+```
+
+## Переменные окружения
+
+Создайте файл `.env` со значениями:
+
+```
+SMTP_HOST=<smtp host>
+SMTP_PORT=<smtp port>
+SMTP_USER=<smtp user>
+SMTP_PASS=<smtp password>
+SECURITY_EMAIL=<email получателя>
+```
+
+## Запуск
+
+```bash
+uvicorn entry_pass_generator.webhook:app --reload
+```
+
+## Пример запроса
+
+```bash
+curl -X POST http://localhost:8080/webhook \
+    -H "Content-Type: application/json" \
+    -d '{"full_name":"Иванов И.И.","vehicle_plate":"A123BC77","start_date":"2024-01-01","end_date":"2024-01-02","purpose":"Доставка оборудования"}'
+```

--- a/entry_pass_generator/__init__.py
+++ b/entry_pass_generator/__init__.py
@@ -1,0 +1,3 @@
+"""Entry pass generator package."""
+
+from .app import models, pdf, mail, webhook  # re-export

--- a/entry_pass_generator/app/mail.py
+++ b/entry_pass_generator/app/mail.py
@@ -1,0 +1,30 @@
+import os
+import smtplib
+from email.message import EmailMessage
+from dotenv import load_dotenv
+
+from .models import EntryRequest
+
+load_dotenv()
+
+SMTP_HOST = os.getenv("SMTP_HOST")
+SMTP_PORT = int(os.getenv("SMTP_PORT", "0"))
+SMTP_USER = os.getenv("SMTP_USER")
+SMTP_PASS = os.getenv("SMTP_PASS")
+SECURITY_EMAIL = os.getenv("SECURITY_EMAIL")
+
+
+def send_to_security(pdf: bytes, data: EntryRequest) -> None:
+    """Send generated PDF to security via email."""
+    msg = EmailMessage()
+    msg["Subject"] = "Служебная записка на въезд"
+    msg["From"] = SMTP_USER
+    msg["To"] = SECURITY_EMAIL
+    msg.set_content(
+        f"Служебная записка для {data.full_name} во вложении.")
+    msg.add_attachment(pdf, maintype="application", subtype="pdf",
+                       filename="entry_pass.pdf")
+
+    with smtplib.SMTP_SSL(SMTP_HOST, SMTP_PORT) as server:
+        server.login(SMTP_USER, SMTP_PASS)
+        server.send_message(msg)

--- a/entry_pass_generator/app/models.py
+++ b/entry_pass_generator/app/models.py
@@ -1,0 +1,19 @@
+from datetime import date
+from pydantic import BaseModel, ValidationError
+
+class EntryRequest(BaseModel):
+    """Schema of incoming entry request."""
+
+    full_name: str
+    vehicle_plate: str | None = None
+    start_date: date
+    end_date: date
+    purpose: str
+
+
+def validate_request(data: dict) -> EntryRequest:
+    """Validate raw dict and return EntryRequest."""
+    try:
+        return EntryRequest(**data)
+    except ValidationError as e:
+        raise ValueError(e.errors())

--- a/entry_pass_generator/app/pdf.py
+++ b/entry_pass_generator/app/pdf.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+from jinja2 import Environment, FileSystemLoader
+from weasyprint import HTML
+
+from .models import EntryRequest
+
+TEMPLATE_DIR = Path(__file__).parent / "templates"
+
+env = Environment(loader=FileSystemLoader(TEMPLATE_DIR))
+
+def render_pdf(data: EntryRequest) -> bytes:
+    """Render PDF bytes from EntryRequest."""
+    template = env.get_template("sz_template.html")
+    html_content = template.render(**data.model_dump())
+    pdf = HTML(string=html_content).write_pdf()
+    return pdf

--- a/entry_pass_generator/app/templates/sz_template.html
+++ b/entry_pass_generator/app/templates/sz_template.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font-family: DejaVu Sans, sans-serif; margin: 2em; }
+        header { text-align: center; margin-bottom: 2em; }
+        footer { margin-top: 3em; }
+    </style>
+</head>
+<body>
+<header>
+    <h1>Служебная записка</h1>
+    <p>на въезд на территорию</p>
+</header>
+<p>Прошу оформить пропуск для {{ full_name }}<br>
+{% if vehicle_plate %}Номер автомобиля: {{ vehicle_plate }}<br>{% endif %}
+Срок действия: с {{ start_date }} по {{ end_date }}.<br>
+Цель въезда: {{ purpose }}.
+</p>
+<footer>
+    <p style="text-align:right;">___________/И.О.Ф./</p>
+</footer>
+</body>
+</html>

--- a/entry_pass_generator/app/webhook.py
+++ b/entry_pass_generator/app/webhook.py
@@ -1,0 +1,18 @@
+from fastapi import FastAPI, HTTPException
+
+from .models import validate_request, EntryRequest
+from .pdf import render_pdf
+from .mail import send_to_security
+
+app = FastAPI()
+
+@app.post("/webhook")
+def webhook(data: dict):
+    try:
+        entry_request: EntryRequest = validate_request(data)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    pdf_bytes = render_pdf(entry_request)
+    send_to_security(pdf_bytes, entry_request)
+    return {"status": "ok"}

--- a/entry_pass_generator/pyproject.toml
+++ b/entry_pass_generator/pyproject.toml
@@ -1,0 +1,21 @@
+[tool.poetry]
+name = "entry_pass_generator"
+version = "0.1.0"
+description = "Automates creation of entry pass service notes"
+authors = ["Auto Generated"]
+
+[tool.poetry.dependencies]
+python = "^3.12"
+python-dotenv = "*"
+jinja2 = "*"
+weasyprint = "62.*"
+pydantic = "*"
+fastapi = "*"
+uvicorn = "*"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "*"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/entry_pass_generator/tests/test_models.py
+++ b/entry_pass_generator/tests/test_models.py
@@ -1,0 +1,20 @@
+from entry_pass_generator.app.models import validate_request, EntryRequest
+import pytest
+from datetime import date
+
+def test_validate_request_success():
+    data = {
+        "full_name": "Иванов И.И.",
+        "vehicle_plate": "A123BC77",
+        "start_date": "2024-01-01",
+        "end_date": "2024-01-02",
+        "purpose": "test"
+    }
+    req = validate_request(data)
+    assert isinstance(req, EntryRequest)
+    assert req.full_name == "Иванов И.И."
+
+
+def test_validate_request_fail():
+    with pytest.raises(ValueError):
+        validate_request({"full_name": "", "start_date": "not-a-date"})

--- a/entry_pass_generator/tests/test_pdf.py
+++ b/entry_pass_generator/tests/test_pdf.py
@@ -1,0 +1,15 @@
+from entry_pass_generator.app.pdf import render_pdf
+from entry_pass_generator.app.models import EntryRequest
+
+
+def test_render_pdf_bytes():
+    data = EntryRequest(
+        full_name="Иванов И.И.",
+        vehicle_plate="A123BC77",
+        start_date="2024-01-01",
+        end_date="2024-01-02",
+        purpose="test",
+    )
+    pdf = render_pdf(data)
+    assert isinstance(pdf, (bytes, bytearray))
+    assert len(pdf) > 0

--- a/entry_pass_generator/webhook.py
+++ b/entry_pass_generator/webhook.py
@@ -1,0 +1,2 @@
+"""Wrapper for uvicorn entry point."""
+from .app.webhook import app


### PR DESCRIPTION
## Summary
- implement `entry_pass_generator` package with FastAPI webhook, PDF creation via WeasyPrint and email sending
- add Dockerfile, Poetry config and minimal README instructions
- provide unit tests for input validation and PDF generation
- ignore Python bytecode

## Testing
- `PYTHONPATH=. pytest -q entry_pass_generator/tests`

------
https://chatgpt.com/codex/tasks/task_e_6852947abeac8333bdb6b7217c4807d8