### PR TITLE
Add PDF generator web interface

### DIFF
--- a/entry_pass_generator/app/templates/index.html
+++ b/entry_pass_generator/app/templates/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <title>PDF Generator</title>
+</head>
+<body>
+    <h1>Создание служебной записки</h1>
+    <form action="/generate" method="post">
+        <label>ФИО:<br><input type="text" name="full_name" required></label><br>
+        <label>Номер автомобиля:<br><input type="text" name="vehicle_plate"></label><br>
+        <label>Дата начала:<br><input type="date" name="start_date" required></label><br>
+        <label>Дата окончания:<br><input type="date" name="end_date" required></label><br>
+        <label>Цель:<br><input type="text" name="purpose" required></label><br>
+        <button type="submit">Создать PDF</button>
+    </form>
+</body>
+</html>

--- a/entry_pass_generator/app/webhook.py
+++ b/entry_pass_generator/app/webhook.py
@@ -1,10 +1,17 @@
-from fastapi import FastAPI, HTTPException
+from pathlib import Path
+import io
+
+from fastapi import FastAPI, HTTPException, Form
+from fastapi.responses import FileResponse, StreamingResponse, HTMLResponse
 
 from .models import validate_request, EntryRequest
 from .pdf import render_pdf
 from .mail import send_to_security
 
 app = FastAPI()
+
+TEMPLATE_DIR = Path(__file__).parent / "templates"
+INDEX_HTML = TEMPLATE_DIR / "index.html"
 
 @app.post("/webhook")
 def webhook(data: dict):
@@ -16,3 +23,37 @@ def webhook(data: dict):
     pdf_bytes = render_pdf(entry_request)
     send_to_security(pdf_bytes, entry_request)
     return {"status": "ok"}
+
+
+@app.get("/", response_class=HTMLResponse)
+def index():
+    """Serve simple HTML form for data input."""
+    return FileResponse(INDEX_HTML)
+
+
+@app.post("/generate")
+def generate(
+    full_name: str = Form(...),
+    vehicle_plate: str | None = Form(None),
+    start_date: str = Form(...),
+    end_date: str = Form(...),
+    purpose: str = Form(...),
+):
+    data_dict = {
+        "full_name": full_name,
+        "vehicle_plate": vehicle_plate,
+        "start_date": start_date,
+        "end_date": end_date,
+        "purpose": purpose,
+    }
+    try:
+        entry_request: EntryRequest = validate_request(data_dict)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    pdf_bytes = render_pdf(entry_request)
+    return StreamingResponse(
+        io.BytesIO(pdf_bytes),
+        media_type="application/pdf",
+        headers={"Content-Disposition": "attachment; filename=entry_pass.pdf"},
+    )

--- a/entry_pass_generator/tests/test_web.py
+++ b/entry_pass_generator/tests/test_web.py
@@ -1,0 +1,19 @@
+from fastapi.testclient import TestClient
+from entry_pass_generator.app.webhook import app
+
+client = TestClient(app)
+
+def test_generate_pdf_endpoint():
+    response = client.post(
+        "/generate",
+        data={
+            "full_name": "Иванов И.И.",
+            "vehicle_plate": "A123BC77",
+            "start_date": "2024-01-01",
+            "end_date": "2024-01-02",
+            "purpose": "test",
+        },
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/pdf")
+    assert len(response.content) > 0


### PR DESCRIPTION
## Summary
- create a minimal HTML form template
- extend FastAPI app with routes to display the form and return generated PDF
- add tests for the new `/generate` route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685296b27c1c8333832b4fa23b44d92a